### PR TITLE
Fix Typos

### DIFF
--- a/src/components/Perps/Sidebar/AccountOverview.tsx
+++ b/src/components/Perps/Sidebar/AccountOverview.tsx
@@ -176,7 +176,7 @@ export function AccountOverview() {
         </Box>
       </Box>
       <Box mb="1">
-        Availble Margin{" "}
+        Available Margin{" "}
         <Box display="inline" float="right">
           <Text display="inline" fontFamily="mono">
             <Amount

--- a/src/components/Perps/Sidebar/OrderForm/OrderForm.tsx
+++ b/src/components/Perps/Sidebar/OrderForm/OrderForm.tsx
@@ -111,7 +111,7 @@ export function OrderForm({ refetch }: Props) {
                   }}
                 >
                   <NumberInputField />
-                  <InputRightElement width="6rem">USD</InputRightElement>
+                  <InputRightElement width="6rem">ETH</InputRightElement>
                 </NumberInput>
               </InputGroup>
             </FormControl>

--- a/src/constants/markets.ts
+++ b/src/constants/markets.ts
@@ -11,7 +11,7 @@ interface MarketData {
 export const perpsMarkets: MarketData = {
   420: {
     ETH: {
-      marketId: 4,
+      marketId: 5,
       tradingViewSymbol: "PYTH:ETHUSD",
       synth: "snxETH",
     },


### PR DESCRIPTION
* The order value is labeled "USD" but the input is measured in amounts of the underlying asset (ETH)
* "Available margin" has a typo
* Update ETH `marketId` to 5